### PR TITLE
Add question extraction utility and JSON banks

### DIFF
--- a/problem-set-1/README.MD
+++ b/problem-set-1/README.MD
@@ -1,3 +1,6 @@
 # Intro to Probability
 
 Full question and answer details are documented in `../doc/audit_ps1_ps2.md`.
+
+The machine-readable questions used by the PDF generator and web app are in
+`question_bank.json`.

--- a/problem-set-1/question_bank.json
+++ b/problem-set-1/question_bank.json
@@ -1,0 +1,352 @@
+[
+  {
+    "id": 1,
+    "text": "A survey of 200 social science students revealed that 120 were enrolled in 'Statistics for Social Sciences', 80 in 'Research Methods', and 50 were enrolled in both. What is the probability that a randomly selected student is enrolled in 'Statistics for Social Sciences' but NOT 'Research Methods'?",
+    "topic_short": "Basic Probability (Sets)",
+    "options": [
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.25\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.35\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.60\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.40\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "Let S be the event of being enrolled in Statistics, and R be in Research Methods. We are given \\( \\displaystyle \\scriptsize  P(S) = 120/200 = 0.60\\), \\( \\displaystyle \\scriptsize  P(R) = 80/200 = 0.40\\), and \\( \\displaystyle \\scriptsize  P(S \\cap R) = 50/200 = 0.25\\). We want \\( \\displaystyle \\scriptsize  P(S \\cap R^c) = P(S) - P(S \\cap R) = 0.60 - 0.25 = 0.35\\)."
+  },
+  {
+    "id": 2,
+    "text": "In a particular city, the probability of rain on any given day is 0.3. What is the probability that it will NOT rain on a given day?",
+    "topic_short": "Complement Rule",
+    "options": [
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.3\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.5\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.7\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 1.0\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "c",
+    "explanation": "Let A be the event that it rains. \\( \\displaystyle \\scriptsize  P(A) = 0.3\\). The event that it does not rain is the complement of A, denoted \\( \\displaystyle \\scriptsize  A^c\\). \\( \\displaystyle \\scriptsize  P(A^c) = 1 - P(A) = 1 - 0.3 = 0.7\\)."
+  },
+  {
+    "id": 3,
+    "text": "A university department offers two distinct elective seminars for sociology majors: 'Urban Sociology' and 'Rural Sociology'. A student can only enroll in one. The probability a student chooses 'Urban Sociology' is 0.4, and 'Rural Sociology' is 0.35. What is the probability a student chooses one of these two seminars?",
+    "topic_short": "Addition Rule (Mutually Exclusive)",
+    "options": [
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.05\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.14\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.75\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 1.00\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "c",
+    "explanation": "Let U be choosing Urban Sociology and R be choosing Rural Sociology. Since a student can only enroll in one, the events are mutually exclusive. \\( \\displaystyle \\scriptsize  P(U) = 0.4\\), \\( \\displaystyle \\scriptsize  P(R) = 0.35\\). So, \\( \\displaystyle \\scriptsize  P(U \\cup R) = P(U) + P(R) = 0.4 + 0.35 = 0.75\\)."
+  },
+  {
+    "id": 4,
+    "text": "In a survey of community members, 40% supported a new park (Event A), and 50% supported a library renovation (Event B). 20% supported both initiatives. What is the probability that a randomly selected member supported the park OR the library renovation (or both)?",
+    "topic_short": "Addition Rule (Not Mutually Exclusive)",
+    "options": [
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.90\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.70\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.60\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.20\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "We use the addition rule: \\( \\displaystyle \\scriptsize  P(A \\cup B) = P(A) + P(B) - P(A \\cap B)\\). Given \\( \\displaystyle \\scriptsize  P(A)=0.40\\), \\( \\displaystyle \\scriptsize  P(B)=0.50\\), and \\( \\displaystyle \\scriptsize  P(A \\cap B)=0.20\\). So, \\( \\displaystyle \\scriptsize  P(A \\cup B) = 0.40 + 0.50 - 0.20 = 0.70\\)."
+  },
+  {
+    "id": 5,
+    "text": "A city has two independent traffic lights. The first traffic light is green with a probability of 0.7. The second traffic light is green with a probability of 0.6. What is the probability that both traffic lights are green when a car approaches them?",
+    "topic_short": "Multiplication Rule (Independent)",
+    "options": [
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.10\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 1.30\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.42\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.88\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "c",
+    "explanation": "Let A be the event that the first light is green, and B be the event that the second light is green. Since the events are independent, \\( \\displaystyle \\scriptsize  P(A \\cap B) = P(A) \\times P(B) = 0.7 \\times 0.6 = 0.42\\)."
+  },
+  {
+    "id": 6,
+    "text": "A small committee consists of 4 sociologists and 3 psychologists. Two members are selected at random, one after another without replacement, to lead a discussion. What is the probability that the first selected is a sociologist and the second is a psychologist?",
+    "topic_short": "Multiplication Rule (Dependent)",
+    "options": [
+      {
+        "text": "\\( \\displaystyle \\scriptsize 12/49\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 12/42\\) or \\(2/7\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 7/12\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 1/7\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "Total members = 7. \\( \\displaystyle \\scriptsize  P(\\text{1st is Sociologist}) = 4/7\\). After selecting one sociologist, there are 6 members left, including 3 psychologists. \\( \\displaystyle \\scriptsize  P(\\text{2nd is Psychologist} | \\text{1st is Sociologist}) = 3/6 = 1/2\\). So, \\( \\displaystyle \\scriptsize  P(\\text{S1 and P2}) = (4/7) \\times (3/6) = 12/42 = 2/7\\)."
+  },
+  {
+    "id": 7,
+    "text": "The probability that a student passes a research methods exam is 0.8 (Event P). The probability that a student both passes the exam AND completes all homework assignments is 0.72 (Event P \\(\\cap\\) H). Given that a student passed the exam, what is the probability they completed all homework assignments?",
+    "topic_short": "Conditional Probability (Direct)",
+    "options": [
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.72\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.80\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.90\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.576\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "c",
+    "explanation": "We want to find \\( \\displaystyle \\scriptsize  P(H|P)\\). We know \\( \\displaystyle \\scriptsize  P(H|P) = P(P \\cap H) / P(P)\\). Given \\( \\displaystyle \\scriptsize  P(P \\cap H) = 0.72\\) and \\( \\displaystyle \\scriptsize  P(P) = 0.8\\). So, \\( \\displaystyle \\scriptsize  P(H|P) = 0.72 / 0.8 = 0.90\\)."
+  },
+  {
+    "id": 8,
+    "text": "A study on voting patterns produced the following table for 1000 respondents: <table class='w-full text-sm text-left text-gray-500 my-2 border'> <thead class='text-xs text-gray-700 uppercase bg-gray-50'><tr><th class='px-2 py-1 border'>Age Group</th><th class='px-2 py-1 border'>Voted</th><th class='px-2 py-1 border'>Did Not Vote</th><th class='px-2 py-1 border'>Total</th></tr></thead><tbody><tr class='bg-white border-b'><td class='px-2 py-1 border'>18-29</td><td class='px-2 py-1 border'>150</td><td class='px-2 py-1 border'>100</td><td class='px-2 py-1 border'>250</td></tr><tr class='bg-white border-b'><td class='px-2 py-1 border'>30+</td><td class='px-2 py-1 border'>550</td><td class='px-2 py-1 border'>200</td><td class='px-2 py-1 border'>750</td></tr><tr class='bg-gray-50 font-semibold'><td class='px-2 py-1 border'>Total</td><td class='px-2 py-1 border'>700</td><td class='px-2 py-1 border'>300</td><td class='px-2 py-1 border'>1000</td></tr></tbody></table> Given that a randomly selected respondent is from the 18-29 age group, what is the probability that they voted?",
+    "topic_short": "Conditional Probability (Table)",
+    "options": [
+      {
+        "text": "\\( \\displaystyle \\scriptsize 150/700\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 150/1000\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 150/250\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 250/1000\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "c",
+    "explanation": "We are given that the respondent is from the 18-29 age group. There are 250 such respondents. Out of these, 150 voted. So, \\( \\displaystyle \\scriptsize  P(\\text{{Voted}} | \\text{18-29 age}) = 150 / 250 = 0.6\\)."
+  },
+  {
+    "id": 9,
+    "text": "A city's population is 60% urban dwellers and 40% suburban dwellers. 5% of urban dwellers are dissatisfied with public transport, while 10% of suburban dwellers are dissatisfied. What is the overall probability that a randomly selected resident is dissatisfied with public transport?",
+    "topic_short": "Total Probability",
+    "options": [
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.075\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.070\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.030\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.040\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "Let U be Urban, S be Suburban, D be Dissatisfied. \\( \\displaystyle \\scriptsize  P(U)=0.6, P(S)=0.4\\). \\( \\displaystyle \\scriptsize  P(D|U)=0.05, P(D|S)=0.10\\). Using Law of Total Probability: \\( \\displaystyle \\scriptsize  P(D) = P(D|U)P(U) + P(D|S)P(S) = (0.05)(0.6) + (0.10)(0.4) = 0.03 + 0.04 = 0.07\\)."
+  },
+  {
+    "id": 10,
+    "text": "Referring to the previous question: If a randomly selected resident is dissatisfied with public transport, what is the probability that they are an urban dweller?",
+    "topic_short": "Bayes' Theorem",
+    "options": [
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.03/0.07 \\approx 0.429\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.04/0.07 \\approx 0.571\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.60\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.05\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "We want \\( \\displaystyle \\scriptsize  P(U|D)\\). Using Bayes' Theorem: \\( \\displaystyle \\scriptsize  P(U|D) = [P(D|U)P(U)] / P(D)\\). From previous Q, \\( \\displaystyle \\scriptsize  P(D|U)P(U) = 0.03\\) and \\( \\displaystyle \\scriptsize  P(D) = 0.07\\). So, \\( \\displaystyle \\scriptsize  P(U|D) = 0.03 / 0.07 \\approx 0.4286\\)."
+  },
+  {
+    "id": 11,
+    "text": "A student is taking a multiple-choice quiz. For any given question, the student knows the answer with probability 0.6. If they don't know the answer (probability 0.4), they guess randomly from 4 options. What is the probability the student answers a question correctly?",
+    "topic_short": "Total Probability",
+    "options": [
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.60\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.70\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.25\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.10\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "Let K be event student knows answer, C be event student answers correctly. \\( \\displaystyle \\scriptsize  P(K) = 0.6\\), so \\( \\displaystyle \\scriptsize  P(K^c) = 0.4\\). \\( \\displaystyle \\scriptsize  P(C|K) = 1\\). If they guess, there are 4 options, so \\( \\displaystyle \\scriptsize  P(C|K^c) = 1/4 = 0.25\\). \\( \\displaystyle \\scriptsize  P(C) = P(C|K)P(K) + P(C|K^c)P(K^c) = (1)(0.6) + (0.25)(0.4) = 0.6 + 0.1 = 0.70\\)."
+  },
+  {
+    "id": 12,
+    "text": "From the previous question: If the student answered a question correctly, what is the probability that they actually knew the answer?",
+    "topic_short": "Bayes' Theorem",
+    "options": [
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.6/0.7 \\approx 0.857\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.1/0.7 \\approx 0.143\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.6\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.7\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "We want \\( \\displaystyle \\scriptsize  P(K|C)\\). Using Bayes' Theorem: \\( \\displaystyle \\scriptsize  P(K|C) = [P(C|K)P(K)] / P(C)\\). We have \\( \\displaystyle \\scriptsize  P(C|K)P(K) = (1)(0.6) = 0.6\\). From the previous question, \\( \\displaystyle \\scriptsize  P(C) = 0.7\\). So, \\( \\displaystyle \\scriptsize  P(K|C) = 0.6 / 0.7 \\approx 0.8571\\)."
+  },
+  {
+    "id": 13,
+    "text": "A focus group has 5 women and 3 men. If two people are randomly selected without replacement to give their opinions, what is the probability that both selected are women?",
+    "topic_short": "Dependent Events / Combinatorics",
+    "options": [
+      {
+        "text": "\\( \\displaystyle \\scriptsize 25/64\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 20/56\\) or \\(5/14\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 15/56\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 5/8\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "Total people = 8. \\( \\displaystyle \\scriptsize  P(\\text{1st is Woman}) = 5/8\\). After selecting one woman, 4 women and 7 people remain. \\( \\displaystyle \\scriptsize  P(\\text{2nd is Woman} | \\text{1st is Woman}) = 4/7\\). So, \\( \\displaystyle \\scriptsize  P(\\text{W1 and W2}) = (5/8) \\times (4/7) = 20/56 = 5/14\\)."
+  },
+  {
+    "id": 14,
+    "text": "In a survey, 30% of respondents are aged 18-25. Among the 18-25 age group, 60% use social media platform 'SociConnect'. Among respondents older than 25 (i.e., the other 70%), 40% use 'SociConnect'. If a randomly selected respondent uses 'SociConnect', what's the probability they are in the 18-25 age group?",
+    "topic_short": "Bayes' Theorem (Mixed)",
+    "options": [
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.18 / 0.46 \\approx 0.391\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.28 / 0.46 \\approx 0.609\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.18\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\( \\displaystyle \\scriptsize 0.46\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "Let A be age 18-25, A_c be older. Let S be uses SociConnect. \\( \\displaystyle \\scriptsize  P(A) = 0.30\\), so \\( \\displaystyle \\scriptsize  P(A_c) = 0.70\\). \\( \\displaystyle \\scriptsize  P(S|A) = 0.60\\), \\( \\displaystyle \\scriptsize  P(S|A_c) = 0.40\\). First, find \\( \\displaystyle \\scriptsize  P(S)\\) using total probability: \\( \\displaystyle \\scriptsize  P(S) = P(S|A)P(A) + P(S|A_c)P(A_c) = (0.60)(0.30) + (0.40)(0.70) = 0.18 + 0.28 = 0.46\\). Now, find \\( \\displaystyle \\scriptsize  P(A|S) = [P(S|A)P(A)] / P(S) = 0.18 / 0.46 \\approx 0.3913\\)."
+  }
+]

--- a/problem-set-2/README.MD
+++ b/problem-set-2/README.MD
@@ -5,3 +5,5 @@
 - Hypothesis testing: 1 proportion.
 
 For a full audit of the self-assessment questions, see `../doc/audit_ps1_ps2.md`.
+
+A JSON export of the web app questions is available in `question_bank.json`.

--- a/problem-set-2/question_bank.json
+++ b/problem-set-2/question_bank.json
@@ -1,0 +1,527 @@
+[
+  {
+    "id": 1,
+    "text": "In statistical inference, an estimator is a rule or formula used to estimate a population parameter based on sample data. Which of the following statements <strong>best describes the property of an unbiased estimator</strong>?",
+    "topic_short": "Estimator Properties",
+    "options": [
+      {
+        "text": "The expected value of the estimator equals the true population parameter it estimates.",
+        "value": "a"
+      },
+      {
+        "text": "The estimator has zero variance, regardless of the sample size used.",
+        "value": "b"
+      },
+      {
+        "text": "The estimator always produces the exact value of the population parameter.",
+        "value": "c"
+      },
+      {
+        "text": "The sampling distribution of the estimator is uniformly distributed.",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "An estimator is said to be unbiased if, on average across many samples, it hits the true parameter value. This means that the <strong>expected value</strong> of the estimator is equal to the parameter it estimates. Zero variance or perfect accuracy are not required (nor are they typical), and there is no requirement that the sampling distribution be uniform."
+  },
+  {
+    "id": 2,
+    "text": "Two unbiased estimators A and B estimate the same parameter. If Var(A)=4 and Var(B)=5, which estimator is more efficient?",
+    "topic_short": "Estimator Efficiency",
+    "options": [
+      {
+        "text": "Estimator A",
+        "value": "a"
+      },
+      {
+        "text": "Estimator B",
+        "value": "b"
+      },
+      {
+        "text": "Both equally efficient",
+        "value": "c"
+      },
+      {
+        "text": "Cannot determine",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "Efficiency compares the variances of unbiased estimators; the one with smaller variance (A) is more efficient."
+  },
+  {
+    "id": 3,
+    "text": "According to the Central Limit Theorem, what is the approximate sampling distribution of the sample mean for large n when sampling from a population with mean \\( \\mu \\) and standard deviation \\( \\sigma \\)?",
+    "topic_short": "Central Limit Theorem",
+    "options": [
+      {
+        "text": "\\( N(\\mu, \\sigma/\\sqrt{n}) \\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( N(0, 1) \\)",
+        "value": "b"
+      },
+      {
+        "text": "\\( N(\\mu, \\sigma ) \\)",
+        "value": "c"
+      },
+      {
+        "text": "Same as the original distribution",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "The CLT states that the standardized sample mean approaches a normal distribution with mean \\( \\mu \\) and standard deviation \\( \\sigma/\\sqrt{n} \\)."
+  },
+  {
+    "id": 4,
+    "text": "A random sample of 100 observations has a sample mean of 50 and a sample standard deviation of 10. What is the standard error of the sample mean?",
+    "topic_short": "Standard Error",
+    "options": [
+      {
+        "text": "10",
+        "value": "a"
+      },
+      {
+        "text": "5",
+        "value": "b"
+      },
+      {
+        "text": "1",
+        "value": "c"
+      },
+      {
+        "text": "0.1",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "c",
+    "explanation": "SE of the mean is \\(  s/\\sqrt{n} = 10/\\sqrt{100} = 1. \\)"
+  },
+  {
+    "id": 5,
+    "text": "Suppose a random sample of 100 observations is taken from a normally distributed population. The sample has a mean of 50 and a sample standard deviation of 10. Based on this information, what is the approximate probability that the sample mean exceeds 52?",
+    "topic_short": "Using the CLT",
+    "options": [
+      {
+        "text": "\\(0.50\\) \u2014 The probability that the mean is greater than its expected value.",
+        "value": "a"
+      },
+      {
+        "text": "\\(0.023\\) \u2014 The upper-tail probability beyond a Z-score of 2.",
+        "value": "b"
+      },
+      {
+        "text": "\\(0.977\\) \u2014 The cumulative probability below a Z-score of 2.",
+        "value": "c"
+      },
+      {
+        "text": "\\(0.10\\) \u2014 A rough approximation based on an informal rule of thumb.",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "To find the probability that the sample mean exceeds 52, we use the Central Limit Theorem. The standard error of the mean is \\( SE = \\frac{s}{\\sqrt{n}} = \\frac{10}{\\sqrt{100}} = 1 \\). The Z-score is then \\( Z = \\frac{52 - 50}{1} = 2 \\). Using standard normal tables or a calculator, the probability that \\( Z > 2 \\) is approximately 0.023."
+  },
+  {
+    "id": 6,
+    "text": "A city council is considering a new public transportation policy and commissions a survey to gauge public opinion. Out of 400 randomly selected residents, 120 indicate they support the proposed policy. Based on this sample, what is the <strong>95% confidence interval</strong> for the true proportion of the population that supports the policy?",
+    "topic_short": "Confidence Interval for \\(p\\)",
+    "options": [
+      {
+        "text": "\\([0.30 \\pm 0.05]\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\([0.255, 0.345]\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\([0.230, 0.370]\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\([0.295, 0.305]\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "From the survey, the sample proportion is \\( \\hat{p} = 120/400 = 0.30 \\). The standard error is \\( SE = \\sqrt{\\frac{0.3(0.7)}{400}} \\approx 0.0229 \\). Using a 95% confidence level, the margin of error is \\( ME = 1.96 \\times SE \\approx 0.045 \\). Thus, the 95% confidence interval is \\( 0.30 \\pm 0.045 = [0.255, 0.345] \\). This means we are 95% confident the true proportion of residents who support the policy lies within this range."
+  },
+  {
+    "id": 7,
+    "text": "A national polling organization surveys 1,000 voters to estimate support for a proposed education reform policy. The poll finds that 48% of respondents favor the policy. A policymaker wants to test whether this level of support is significantly different from 50%, the threshold assumed under the status quo. To test \\( H_0: p = 0.50 \\) versus \\( H_a: p \\neq 0.50 \\), what is the value of the Z test statistic based on the sample?",
+    "topic_short": "Hypothesis Test for \\(p\\)",
+    "options": [
+      {
+        "text": "-1.27",
+        "value": "a"
+      },
+      {
+        "text": "1.27",
+        "value": "b"
+      },
+      {
+        "text": "-2.50",
+        "value": "c"
+      },
+      {
+        "text": "0",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "The test statistic is calculated using \\( Z = \\frac{\\hat{p} - p_0}{\\sqrt{p_0(1 - p_0)/n}} = \\frac{0.48 - 0.50}{\\sqrt{0.5(0.5)/1000}} \\approx -1.27 \\)."
+  },
+  {
+    "id": 8,
+    "text": "Based on the test statistic from the previous question and using a 5% significance level, what is the appropriate conclusion regarding public support for the education reform policy?",
+    "topic_short": "Hypothesis Test Decision",
+    "options": [
+      {
+        "text": "Reject H0",
+        "value": "a"
+      },
+      {
+        "text": "Fail to reject H0",
+        "value": "b"
+      },
+      {
+        "text": "Insufficient information",
+        "value": "c"
+      },
+      {
+        "text": "Accept H0",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "With \\( Z \\approx -1.27 \\), the test statistic falls within the non-rejection region since \\( |Z| < 1.96 \\). Therefore, we fail to reject the null hypothesis at the \\( \\alpha = 0.05 \\) level. There is not enough evidence to conclude that public support differs from 50%."
+  },
+  {
+    "id": 9,
+    "text": "In a recent community survey, 192 out of 400 respondents said they felt safe walking alone at night in their neighborhood. Based on this sample, which of the following best represents a <strong>95% confidence interval</strong> for the true proportion of residents who feel safe?",
+    "topic_short": "Confidence Interval for One Proportion",
+    "options": [
+      {
+        "text": "\\([0.43, 0.53]\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\([0.48, 0.52]\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\([0.44, 0.56]\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\([0.40, 0.60]\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "The sample proportion is \\( \\hat{p} = 192/400 = 0.48 \\). The standard error is \\( \\sqrt{0.48(0.52)/400} \\approx 0.025 \\). Using a 95% confidence level, the margin of error is \\( 1.96 \\times 0.025 \\approx 0.049 \\). The interval is approximately \\( 0.48 \\pm 0.05 = [0.43, 0.53] \\)."
+  },
+  {
+    "id": 10,
+    "text": "If a two-sided hypothesis test for a proportion yields a P-value of 0.03, what can you conclude at \u03b1 = 0.05?",
+    "topic_short": "P-value Interpretation",
+    "options": [
+      {
+        "text": "Reject H0",
+        "value": "a"
+      },
+      {
+        "text": "Fail to reject H0",
+        "value": "b"
+      },
+      {
+        "text": "Need a larger sample",
+        "value": "c"
+      },
+      {
+        "text": "The parameter equals the null value",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "Since 0.03 < 0.05, we reject the null hypothesis at the 5% significance level."
+  },
+  {
+    "id": 11,
+    "text": "Which of the following best describes a population parameter?",
+    "topic_short": "Population vs. Sample",
+    "options": [
+      {
+        "text": "A theoretical value describing an entire population",
+        "value": "a"
+      },
+      {
+        "text": "A statistic computed from a sample",
+        "value": "b"
+      },
+      {
+        "text": "A random variable from repeated sampling",
+        "value": "c"
+      },
+      {
+        "text": "The standard error of an estimator",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "Population parameters are fixed values describing the whole population, unlike sample-based statistics."
+  },
+  {
+    "id": 12,
+    "text": "In hypothesis testing, what does it mean to reject the null hypothesis at the 5% significance level?",
+    "topic_short": "Hypothesis Testing Logic",
+    "options": [
+      {
+        "text": "There is strong evidence that the null hypothesis is true.",
+        "value": "a"
+      },
+      {
+        "text": "There is sufficient statistical evidence to reject the null hypothesis in favor of the alternative hypothesis.",
+        "value": "b"
+      },
+      {
+        "text": "The probability that the null hypothesis is true is exactly 5%.",
+        "value": "c"
+      },
+      {
+        "text": "The data were collected with a 5% probability of measurement error.",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "Rejecting the null hypothesis at the 5% significance level means that the observed data are sufficiently inconsistent with what we would expect under the null hypothesis. Specifically, the probability of observing such data (or more extreme) under the assumption that the null is true is less than or equal to 0.05. This provides statistical evidence to support the alternative hypothesis, but it does not prove the alternative is true or that the null is false with certainty."
+  },
+  {
+    "id": 13,
+    "text": "Which statement best describes the concept of the standard error (SE) of an estimator in statistical inference?",
+    "topic_short": "Standard Error vs SD",
+    "options": [
+      {
+        "text": "It measures the spread of the population distribution from which the sample is drawn.",
+        "value": "a"
+      },
+      {
+        "text": "It is the standard deviation of the sampling distribution of the estimator across repeated samples.",
+        "value": "b"
+      },
+      {
+        "text": "It equals the variance of individual observations in the sample.",
+        "value": "c"
+      },
+      {
+        "text": "It remains constant regardless of the sample size.",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "The standard error (SE) quantifies how much an estimator (like the sample mean or proportion) would vary from sample to sample due to random sampling variability. It is the standard deviation of the estimator's sampling distribution, and it generally decreases as the sample size increases."
+  },
+  {
+    "id": 14,
+    "text": "Which of the following is NOT a required condition for the Central Limit Theorem (CLT) to apply to the sampling distribution of the sample mean?",
+    "topic_short": "CLT Assumptions",
+    "options": [
+      {
+        "text": "Observations are independent \u2014 outcomes don\u2019t influence one another.",
+        "value": "a"
+      },
+      {
+        "text": "Observations are identically distributed \u2014 all drawn from the same population distribution.",
+        "value": "b"
+      },
+      {
+        "text": "The population probability distribution must be normal.",
+        "value": "c"
+      },
+      {
+        "text": "Sample size is sufficiently large.",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "c",
+    "explanation": "The CLT does **not** require the population to be normally distributed. It guarantees that the sampling distribution of the sample mean becomes approximately normal as the sample size increases, assuming the observations are independent, identically distributed, and have finite variance. Normality of the population is only necessary when sample sizes are small."
+  },
+  {
+    "id": 15,
+    "text": "If \\( X_i \\sim N(\\mu=50, \\sigma^2=25) \\) and \\( n = 46 \\), what is the sampling distribution of \\( \\bar{X} \\) (the sample mean)?",
+    "topic_short": "Sample Mean Distribution",
+    "options": [
+      {
+        "text": "\\( N(50, 25/46) \\)",
+        "value": "a"
+      },
+      {
+        "text": "\\( N(50, 25) \\)",
+        "value": "b"
+      },
+      {
+        "text": "Binomial(50, 46)",
+        "value": "c"
+      },
+      {
+        "text": "Uniform(46, 50)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "Since the original population is normal, the sample mean \\( \\bar{X} \\) is also normally distributed with the same mean (50) and reduced variance \\( \\sigma^2 / n = 25 / 16 \\)."
+  },
+  {
+    "id": 16,
+    "text": "In hypothesis testing, what is the purpose of the rejection region?",
+    "topic_short": "Rejection Region Concept",
+    "options": [
+      {
+        "text": "It defines the range of sample outcomes considered unlikely under the null hypothesis.",
+        "value": "a"
+      },
+      {
+        "text": "It contains the values most consistent with the null hypothesis.",
+        "value": "b"
+      },
+      {
+        "text": "It marks the interval where the alternative hypothesis is accepted as true.",
+        "value": "c"
+      },
+      {
+        "text": "It shows the values of the population parameter we believe are most likely.",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "The rejection region consists of extreme values of the test statistic that would be unlikely to occur if the null hypothesis were true. If the observed statistic falls in this region, we reject the null hypothesis in favor of the alternative."
+  },
+  {
+    "id": 17,
+    "text": "In a statistical study involving categorical outcomes (e.g., 'yes' or 'no', 'success' or 'failure'), researchers often summarize results using the sample proportion \\(\\hat{p}\\). How is this sample proportion calculated from the data?",
+    "topic_short": "Sample Proportion",
+    "options": [
+      {
+        "text": "Number of successes divided by the sample size",
+        "value": "a"
+      },
+      {
+        "text": "Sample size divided by number of successes",
+        "value": "b"
+      },
+      {
+        "text": "Square root of the number of successes",
+        "value": "c"
+      },
+      {
+        "text": "Number of successes minus failures",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "The sample proportion \\(\\hat{p}\\) is calculated by dividing the number of observed successes (e.g., those who answered 'yes' or had a positive outcome) by the total number of observations in the sample. It serves as a point estimate of the true population proportion \\(p\\)."
+  },
+  {
+    "id": 18,
+    "text": "What is the variance of the sample proportion \\(\\hat{p}\\)?",
+    "topic_short": "Variance of p-hat",
+    "options": [
+      {
+        "text": "\\(p(1-p)/n\\)",
+        "value": "a"
+      },
+      {
+        "text": "\\(p/n\\)",
+        "value": "b"
+      },
+      {
+        "text": "\\(p(1-p)\\)",
+        "value": "c"
+      },
+      {
+        "text": "\\(1/n\\)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "For a binomial sample, \\( Var(\\hat{p}) = p(1-p)/n. \\)"
+  },
+  {
+    "id": 19,
+    "text": "Which Z critical value is used for a 99% confidence interval for a proportion?",
+    "topic_short": "99% Confidence Level",
+    "options": [
+      {
+        "text": "1.645",
+        "value": "a"
+      },
+      {
+        "text": "1.96",
+        "value": "b"
+      },
+      {
+        "text": "2.576",
+        "value": "c"
+      },
+      {
+        "text": "3.29",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "c",
+    "explanation": "A 99% two-sided interval uses the critical value \\( z_{0.995} \\approx 2.576. \\)"
+  },
+  {
+    "id": 20,
+    "text": "Which of the following best describes a correct interpretation of a 95% confidence interval for \\(p\\)?",
+    "topic_short": "Interpreting CIs",
+    "options": [
+      {
+        "text": "In repeated samples, about 95% of such intervals will contain the true p",
+        "value": "a"
+      },
+      {
+        "text": "There is a 95% chance that p equals the sample proportion",
+        "value": "b"
+      },
+      {
+        "text": "The probability that p is inside this one interval is 95%",
+        "value": "c"
+      },
+      {
+        "text": "95% of future sample proportions will fall inside the interval",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "Confidence intervals refer to long-run coverage of the true parameter, not a probability for a single interval."
+  },
+  {
+    "id": 21,
+    "text": "In hypothesis testing, the significance level \\( \\alpha \\) represents:",
+    "topic_short": "Significance Level",
+    "options": [
+      {
+        "text": "The probability of rejecting H0 when it is true",
+        "value": "a"
+      },
+      {
+        "text": "The probability that Ha is true",
+        "value": "b"
+      },
+      {
+        "text": "The probability that the sample data are correct",
+        "value": "c"
+      },
+      {
+        "text": "The P-value of the test",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "The significance level is the tolerated Type I error rate for the test."
+  }
+]

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+
+def load_bank(path: Path):
+    with path.open() as f:
+        return json.load(f)
+
+
+def test_problem_set_1_count_and_ids():
+    data = load_bank(Path('problem-set-1/question_bank.json'))
+    assert len(data) == 14
+    assert data[0]['id'] == 1
+    assert data[-1]['id'] == 14
+
+
+def test_problem_set_2_count_and_ids():
+    data = load_bank(Path('problem-set-2/question_bank.json'))
+    assert len(data) == 21
+    assert data[0]['id'] == 1
+    assert data[-1]['id'] == 21

--- a/tools/extract_questions.py
+++ b/tools/extract_questions.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Extract questions from a web_app index.html file."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+import json5
+
+
+def extract_questions(html_path: Path) -> list[dict]:
+    """Return the questions array parsed from the given HTML file."""
+    text = html_path.read_text(encoding="utf-8")
+    soup = BeautifulSoup(text, "html.parser")
+    script = next((s for s in soup.find_all("script") if s.string and "const questions" in s.string), None)
+    if not script:
+        raise ValueError("questions array not found")
+    stext = script.string
+    start = stext.index("const questions")
+    start = stext.index("[", start)
+    end = stext.index("];", start)
+    array_str = stext[start:end + 1]
+    return json5.loads(array_str)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract question array from HTML")
+    parser.add_argument("html", type=Path, help="Path to web_app/index.html")
+    parser.add_argument("output", type=Path, help="Destination JSON file")
+    args = parser.parse_args()
+    data = extract_questions(args.html)
+    args.output.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- parse question arrays from web apps into JSON
- generate `question_bank.json` for problem-set 1 and 2
- mention JSON exports in each problem-set README
- add regression tests for question counts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866b453ee708332bcea07ce2b5faa13