### PR TITLE
Update documentation for question extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ No build tools, no dependencies – students just open the file.
 * * **Question bank** – YAML/JSON/CSV files with question text, variables, and correct answers.
 * **Jinja/LaTeX templates** – A Python script walks the bank, renders LaTeX, and spits out “Problem Set 1.pdf” and “Solutions 1.pdf”.
 * **Makefile or runner script** – One-liner to rebuild everything when questions change.
+* **Question extraction utility** – Run `tools/extract_questions.py` to export a `question_bank.json` from any `web_app/index.html`.
 
 ---
 
@@ -56,3 +57,13 @@ No build tools, no dependencies – students just open the file.
 * **Each problem-set directory = one week’s slides + web quiz.**
 * **PDFs give the theory; the web quiz gives immediate feedback.**
 * **No heavyweight stacks – everything is static so it works on GitHub Pages or Canvas.**
+
+### 6. Extracting question banks
+
+Run the helper script to convert an existing web quiz into a JSON question bank:
+
+```bash
+python tools/extract_questions.py problem-set-N/web_app/index.html \
+    problem-set-N/question_bank.json
+```
+Replace `N` with the desired week number.

--- a/problem-set-1/README.MD
+++ b/problem-set-1/README.MD
@@ -3,4 +3,8 @@
 Full question and answer details are documented in `../doc/audit_ps1_ps2.md`.
 
 The machine-readable questions used by the PDF generator and web app are in
-`question_bank.json`.
+`question_bank.json`. If you edit `web_app/index.html`, regenerate the JSON with:
+
+```bash
+python ../../tools/extract_questions.py web_app/index.html question_bank.json
+```

--- a/problem-set-2/README.MD
+++ b/problem-set-2/README.MD
@@ -7,3 +7,8 @@
 For a full audit of the self-assessment questions, see `../doc/audit_ps1_ps2.md`.
 
 A JSON export of the web app questions is available in `question_bank.json`.
+If you modify the HTML, rebuild the JSON with:
+
+```bash
+python ../../tools/extract_questions.py web_app/index.html question_bank.json
+```

--- a/problem-set-3/README.MD
+++ b/problem-set-3/README.MD
@@ -8,3 +8,9 @@
 
 See `problem_set_blueprint.md` for a draft question list and `validate_problemset3_computations.py` for a small numeric check script.
 
+Once the HTML quiz is finalised, create `question_bank.json` via:
+
+```bash
+python ../../tools/extract_questions.py web_app/index.html question_bank.json
+```
+


### PR DESCRIPTION
## Summary
- explain how to regenerate question banks in README
- mention extraction script in weekly READMEs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866b94aa51c8332bddf3aa6e59fbcbd