### PR TITLE
Improve extractor robustness

### DIFF
--- a/tools/extract_questions.py
+++ b/tools/extract_questions.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Extract questions from a web_app index.html file."""
+"""Extract question metadata from a web_app `index.html` file.
+
+The script looks for a JavaScript array assignment like ``const questions = [...]``.
+It parses the array using ``json5`` when available so that single quotes or
+trailing commas are accepted.  If ``json5`` is missing, a more robust
+fallback uses Node.js to evaluate the snippet and return valid JSON.  Only if
+Node.js is unavailable do we attempt a very simple transformation to standard
+JSON.  All keys present in the HTML are preserved in the resulting list of
+dictionaries.
+"""
 from __future__ import annotations
 
 import argparse
@@ -7,8 +16,12 @@ import json
 from pathlib import Path
 
 from bs4 import BeautifulSoup
-import json5
 import re
+
+try:  # json5 is optional
+    import json5  # type: ignore
+except ImportError:  # pragma: no cover - fallback if json5 unavailable
+    json5 = None
 
 
 def extract_questions(html_path: Path) -> list[dict]:
@@ -22,7 +35,33 @@ def extract_questions(html_path: Path) -> list[dict]:
             continue
         match = pattern.search(script.string)
         if match:
-            return json5.loads(match.group(1))
+            array_text = match.group(1)
+            if json5:
+                return json5.loads(array_text)
+            try:  # attempt Node.js evaluation for robust parsing
+                import subprocess
+                import tempfile
+                import os
+
+                with tempfile.NamedTemporaryFile('w', delete=False, encoding='utf-8') as tmp:
+                    tmp.write(array_text)
+                    tmp_path = tmp.name
+                node_script = (
+                    "const fs=require('fs');"
+                    "const vm=require('vm');"
+                    "const s=fs.readFileSync(process.argv[1],'utf8');"
+                    "const d=vm.runInNewContext('(' + s + ')');"
+                    "process.stdout.write(JSON.stringify(d));"
+                )
+                result = subprocess.run(['node', '-e', node_script, tmp_path],
+                                       check=True, capture_output=True, text=True)
+                os.unlink(tmp_path)
+                return json.loads(result.stdout)
+            except Exception:
+                # simple transformation as last resort
+                safe = re.sub(r"(\w+)\s*:", r'"\1":', array_text)
+                safe = re.sub(r",\s*(?=[}\]])", "", safe)
+                return json.loads(safe)
 
     raise ValueError("questions array not found")
 


### PR DESCRIPTION
## Summary
- update fallback to use nodejs evaluation when json5 isn't installed
- regenerate question banks for problem set 1 and 2

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866d78638d483328f808f9f4abf3e8e