### PR TITLE
Add problem set generator CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ backed by JSON question banks, with a roadmap toward automated PDF generation.
 | `problem-set-3/`      | In-progress content: blueprint of 20 MCQs and validation utilities.                   |
 | `doc/`                | Internal documentation (`audit_ps1_ps2.md`, `schema.md`).                             |
 | `tools/`              | Helper scripts such as `extract_questions.py`.                                        |
-| `tests/`              | Unit tests ensuring JSON files parse correctly.                                       |
+| `tests/`              | Unit tests ensuring JSON files parse correctly and validate generated TeX.                                       |
 | `Refactor_Roadmap.md` | Milestone plan for moving from the prototype to a full generator pipeline.           |
 | `LICENSE`             | MIT license covering all source files.                                                |
 
@@ -53,6 +53,12 @@ pytest -q
 ```
 
 HTML can be validated with `tidy` and formatted with `prettier` if available.
+
+Generate TeX versions of a problem set using the CLI:
+
+```bash
+python -m generator.build_ps --bank problem-set-N/question_bank.json --out build/
+```
 
 ## 5 · Roadmap
 

--- a/generator/__init__.py
+++ b/generator/__init__.py
@@ -1,0 +1,1 @@
+"""PDF generation utilities."""

--- a/generator/build_ps.py
+++ b/generator/build_ps.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Build problem set and solutions TeX files from a question bank."""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+
+def load_bank(path: Path) -> list[dict]:
+    """Return list of questions from a JSON bank."""
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def render(template, context: dict, out_path: Path) -> None:
+    out_path.write_text(template.render(context), encoding="utf-8")
+
+
+def build(bank_path: Path, out_dir: Path) -> None:
+    questions = load_bank(bank_path)
+    env = Environment(loader=FileSystemLoader(Path(__file__).parent / "templates"))
+    ctx = {"questions": questions, "today": date.today()}
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for name in ("problem_set", "solutions"):
+        tmpl = env.get_template(f"{name}.tex.j2")
+        render(tmpl, ctx, out_dir / f"{name}.tex")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate TeX problem set")
+    parser.add_argument("--bank", type=Path, required=True, help="question_bank.json")
+    parser.add_argument("--out", type=Path, default=Path("."), help="output directory")
+    args = parser.parse_args()
+    build(args.bank, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/generator/templates/problem_set.tex.j2
+++ b/generator/templates/problem_set.tex.j2
@@ -1,0 +1,16 @@
+\documentclass{article}
+\usepackage{amsmath}
+\usepackage{siunitx}
+\begin{document}
+\section*{Problem Set}
+\begin{enumerate}
+{% for q in questions %}
+  \item {{ q.text }}
+  \begin{enumerate}[a)]
+    {% for opt in q.options %}
+    \item {{ opt.text }}
+    {% endfor %}
+  \end{enumerate}
+{% endfor %}
+\end{enumerate}
+\end{document}

--- a/generator/templates/solutions.tex.j2
+++ b/generator/templates/solutions.tex.j2
@@ -1,0 +1,13 @@
+\documentclass{article}
+\usepackage{amsmath}
+\usepackage{siunitx}
+\begin{document}
+\section*{Solutions}
+\begin{enumerate}
+{% for q in questions %}
+  \item {{ q.text }}\\
+  Correct answer: {{ q.correctAnswer | upper }}\\
+  {{ q.explanation }}
+{% endfor %}
+\end{enumerate}
+\end{document}

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,20 @@
+import subprocess
+from pathlib import Path
+
+
+def test_build_tex(tmp_path: Path):
+    bank = Path('problem-set-1/question_bank.json')
+    out = tmp_path
+    subprocess.run([
+        'python', '-m', 'generator.build_ps',
+        '--bank', str(bank),
+        '--out', str(out)
+    ], check=True)
+    ps = out / 'problem_set.tex'
+    sol = out / 'solutions.tex'
+    assert ps.exists()
+    assert sol.exists()
+    tex = ps.read_text()
+    assert '\\begin{enumerate}' in tex
+    assert tex.count('\\item') >= 14
+


### PR DESCRIPTION
## Summary
- implement milestone 3 PDF generator CLI
- provide Jinja2 TeX templates
- document generator usage in README
- add tests for generator outputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686747b770708332b0ba8b47930501f7