### PR TITLE
Add LaTeX build pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Generate TeX versions of a problem set using the CLI:
 python -m generator.build_ps --bank problem-set-N/question_bank.json --out build/
 ```
 
+You can also compile the resulting TeX into PDFs in one step:
+
+```bash
+python -m generator.build_pdf --bank problem-set-N/question_bank.json --out build/
+```
+
 ## 5 · Roadmap
 
 `Refactor_Roadmap.md` describes the planned evolution of the project. Upcoming

--- a/generator/build_pdf.py
+++ b/generator/build_pdf.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Pipeline to generate PDF problem sets from a question bank."""
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from generator import build_ps
+
+
+def compile_tex(tex_path: Path) -> None:
+    """Run pdflatex on the given TeX file."""
+    subprocess.run(
+        [
+            "pdflatex",
+            "-interaction=nonstopmode",
+            "-halt-on-error",
+            tex_path.name,
+        ],
+        cwd=tex_path.parent,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+        check=True,
+    )
+
+
+def build_and_compile(bank: Path, out_dir: Path) -> None:
+    """Generate TeX and compile them to PDFs."""
+    build_ps.build(bank, out_dir)
+    for name in ("problem_set", "solutions"):
+        compile_tex(out_dir / f"{name}.tex")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate PDFs from a question bank"
+    )
+    parser.add_argument(
+        "--bank", type=Path, required=True, help="Path to question_bank.json"
+    )
+    parser.add_argument(
+        "--out", type=Path, default=Path("build"), help="Output directory"
+    )
+    args = parser.parse_args()
+    build_and_compile(args.bank, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,5 +1,7 @@
 import subprocess
 from pathlib import Path
+import shutil
+import pytest
 
 
 def test_build_tex(tmp_path: Path):
@@ -18,3 +20,18 @@ def test_build_tex(tmp_path: Path):
     assert '\\begin{enumerate}' in tex
     assert tex.count('\\item') >= 14
 
+
+@pytest.mark.skipif(
+    shutil.which('pdflatex') is None,
+    reason='pdflatex not installed'
+)
+def test_build_pdf_pipeline(tmp_path: Path):
+    bank = Path('problem-set-1/question_bank.json')
+    out = tmp_path
+    subprocess.run([
+        'python', '-m', 'generator.build_pdf',
+        '--bank', str(bank),
+        '--out', str(out)
+    ], check=True)
+    assert (out / 'problem_set.pdf').exists()
+    assert (out / 'solutions.pdf').exists()


### PR DESCRIPTION
## Summary
- add `build_pdf.py` to generate PDFs from question banks
- document new CLI usage in the README
- test PDF generation pipeline (skips when `pdflatex` is missing)

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68675264098c8332850704363e76effb