### PR TITLE
Fix LaTeX generation for problem set

### DIFF
--- a/generator/templates/problem_set.tex.j2
+++ b/generator/templates/problem_set.tex.j2
@@ -1,6 +1,7 @@
 \documentclass{article}
 \usepackage{amsmath}
 \usepackage{siunitx}
+\usepackage{enumerate}
 \begin{document}
 \section*{Problem Set}
 \begin{enumerate}

--- a/problem-set-1/question_bank.json
+++ b/problem-set-1/question_bank.json
@@ -347,6 +347,6 @@
       }
     ],
     "correctAnswer": "a",
-    "explanation": "Let A be age 18-25, A_c be older. Let S be uses SociConnect. \\( \\displaystyle \\scriptsize  P(A) = 0.30\\), so \\( \\displaystyle \\scriptsize  P(A_c) = 0.70\\). \\( \\displaystyle \\scriptsize  P(S|A) = 0.60\\), \\( \\displaystyle \\scriptsize  P(S|A_c) = 0.40\\). First, find \\( \\displaystyle \\scriptsize  P(S)\\) using total probability: \\( \\displaystyle \\scriptsize  P(S) = P(S|A)P(A) + P(S|A_c)P(A_c) = (0.60)(0.30) + (0.40)(0.70) = 0.18 + 0.28 = 0.46\\). Now, find \\( \\displaystyle \\scriptsize  P(A|S) = [P(S|A)P(A)] / P(S) = 0.18 / 0.46 \\approx 0.3913\\)."
+    "explanation": "Let A be age 18-25, $A_c$ be older. Let S be uses SociConnect. \\( \\displaystyle \\scriptsize  P(A) = 0.30\\), so \\( \\displaystyle \\scriptsize  P(A_c) = 0.70\\). \\( \\displaystyle \\scriptsize  P(S|A) = 0.60\\), \\( \\displaystyle \\scriptsize  P(S|A_c) = 0.40\\). First, find \\( \\displaystyle \\scriptsize  P(S)\\) using total probability: \\( \\displaystyle \\scriptsize  P(S) = P(S|A)P(A) + P(S|A_c)P(A_c) = (0.60)(0.30) + (0.40)(0.70) = 0.18 + 0.28 = 0.46\\). Now, find \\( \\displaystyle \\scriptsize  P(A|S) = [P(S|A)P(A)] / P(S) = 0.18 / 0.46 \\approx 0.3913\\)."
   }
 ]


### PR DESCRIPTION
## Summary
- load `enumerate` package in LaTeX template so optional arguments work
- escape stray underscore in question bank explanation
- verified PDF build and tests

## Testing
- `pytest -q`
- `python -m generator.build_pdf --bank problem-set-1/question_bank.json --out build`

------
https://chatgpt.com/codex/tasks/task_e_6867576c4a1c8332acc95392d52b5676