### PR TITLE
Fix LaTeX pipeline for UTF-8

### DIFF
--- a/generator/templates/problem_set.tex.j2
+++ b/generator/templates/problem_set.tex.j2
@@ -1,6 +1,8 @@
 \documentclass{article}
 \usepackage{amsmath}
 \usepackage{siunitx}
+\usepackage[utf8]{inputenc}
+\usepackage{textgreek}
 \usepackage{enumerate}
 \begin{document}
 \section*{Problem Set}

--- a/generator/templates/solutions.tex.j2
+++ b/generator/templates/solutions.tex.j2
@@ -1,6 +1,8 @@
 \documentclass{article}
 \usepackage{amsmath}
 \usepackage{siunitx}
+\usepackage[utf8]{inputenc}
+\usepackage{textgreek}
 \begin{document}
 \section*{Solutions}
 \begin{enumerate}


### PR DESCRIPTION
## Summary
- enable UTF-8 and Greek characters in TeX templates

## Testing
- `pytest -q`
- `python -m generator.build_pdf --bank problem-set-1/question_bank.json --out build/ps1`
- `python -m generator.build_pdf --bank problem-set-2/question_bank.json --out build/ps2`


------
https://chatgpt.com/codex/tasks/task_e_68676145638c83329f47b993093d524f