### PR TITLE
Validate PS3 computations and add audit log

### DIFF
--- a/problem-set-3/validate_problemset3_computations.py
+++ b/problem-set-3/validate_problemset3_computations.py
@@ -5,7 +5,7 @@ Each helper mirrors the *exact* notation presented in the lecture slides so that
 instructors and students can trace code ↔ formula one‑to‑one.
 
 Run the module as a script to execute built‑in checks against the answer key
-published in *Week5‑Question‑Blueprint.md*.
+published in *problem_set_blueprint.md*.
 
 Example
 -------
@@ -59,7 +59,7 @@ def ci_mu1_minus_mu2(
     n2: int,
     z: float = 1.96,
 ) -> Tuple[float, float]:
-    """Large‑sample CI for \mu₁ − \mu₂ (Lecture 11, slide 12)."""
+    r"""Large‑sample CI for \mu_1 - \mu_2 (Lecture 11, slide 12)."""
     diff = mean1 - mean2
     se = se_xbar_diff(s1, n1, s2, n2)
     me = z * se
@@ -67,7 +67,7 @@ def ci_mu1_minus_mu2(
 
 
 def t_stat_one_mean(xbar: float, mu0: float, s: float, n: int) -> float:
-    """Student‑t statistic for H0 : \mu = \mu₀ (Lecture 12, slide 7)."""
+    r"""Student-t statistic for H0 : \mu = \mu_0 (Lecture 12, slide 7)."""
     return (xbar - mu0) / (s / math.sqrt(n))
 
 
@@ -82,7 +82,7 @@ def df_paired(n: int) -> int:
 Answer = Union[float, Tuple[float, float]]
 
 
-def approx(a: Answer, b: Answer, tol: float = 5e‑3) -> bool:  # noqa: W605
+def approx(a: Answer, b: Answer, tol: float = 5e-3) -> bool:  # noqa: W605
     """Flexible tolerance‑based comparison (scalar or 2‑tuple)."""
     if isinstance(a, tuple):
         return all(abs(x - y) <= tol for x, y in zip(a, b))
@@ -135,7 +135,7 @@ def run_self_checks() -> None:
         status = "PASS" if ok else "FAIL"
         print(f"{qid}: {status}")
         if not ok:
-            print(f"  expected ≈ {key}, got {calc:.4f}")
+            print(f"  expected ≈ {key}, got {calc}")
 
 
 if __name__ == "__main__":

--- a/problem-set-3/validation_audit.md
+++ b/problem-set-3/validation_audit.md
@@ -1,0 +1,32 @@
+# Validation Audit for Problem Set 3
+
+The script `validate_problemset3_computations.py` was reviewed and executed.
+Several issues were found and corrected:
+
+- The default tolerance value used an en dash (`5e–3`) causing a `SyntaxError`.
+  Replaced with `5e-3`.
+- Docstrings containing LaTeX expressions triggered `SyntaxWarning` due to
+  unescaped backslashes. They were converted to raw strings and properly
+  indented.
+- Reference to *Week5-Question-Blueprint.md* was updated to the actual file
+  name `problem_set_blueprint.md`.
+- Output formatting for failing tests now handles tuples correctly.
+
+After fixes, the validation script produced the following output:
+
+```
+W5‑Q14: PASS
+W5‑Q15: FAIL
+  expected ≈ 0.333, got 0.3026315789473684
+W5‑Q16: FAIL
+  expected ≈ (1.6, 6.4), got (1.4110952356666577, 6.588904764333343)
+W5‑Q17: PASS
+W5‑Q18: FAIL
+  expected ≈ 2.67, got 3.079201435678003
+W5‑Q19: PASS
+W5‑Q20: FAIL
+  expected ≈ 1.87, got 1.7748239349298849
+```
+
+Questions 15, 16, 18 and 20 deviate from the published answer key and should be
+reviewed.


### PR DESCRIPTION
## Summary
- fix validate_problemset3_computations.py docstrings and tolerance parameter
- update blueprint file reference and error message formatting
- record audit results in `validation_audit.md`

## Testing
- `pytest -q`
- `python problem-set-3/validate_problemset3_computations.py`

------
https://chatgpt.com/codex/tasks/task_e_6867a85d590483328d942830b3d45ee5