### PR TITLE
Extend validation helpers

### DIFF
--- a/problem-set-3/validate_problemset3_computations.py
+++ b/problem-set-3/validate_problemset3_computations.py
@@ -16,64 +16,31 @@ W5‑Q15: **FAIL** (expected ≈ 0.333, got 0.3026)  ← highlights a key error
 """
 from __future__ import annotations
 
-import math
-from typing import Tuple, Dict, Union
+from typing import Dict, Tuple, Union
+
+from tools.validation_utils import (
+    approx,
+    ci_mu1_minus_mu2,
+    ci_p1_minus_p2,
+    df_paired,
+    df_welch,
+    margin_of_error,
+    margin_of_error_z,
+    pooled_p,
+    p_value,
+    se_hat_p_diff,
+    se_pooled_p_diff,
+    se_xbar_diff,
+    t_stat_one_mean,
+    t_stat_paired,
+    t_stat_two_means,
+    z_stat_two_props,
+)
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Custom statistical helpers (notation ≈ slides)
 # ───────────────────────────────────────────────────────────────────────────────
 
-def se_hat_p_diff(p1_hat: float, n1: int, p2_hat: float, n2: int) -> float:
-    """Standard error of the difference of two sample proportions.
-
-    Formula (Lecture 9, slide 12)::
-        SE = sqrt[ p1(1−p1)/n1 + p2(1−p2)/n2 ]
-    """
-    return math.sqrt(p1_hat * (1 - p1_hat) / n1 + p2_hat * (1 - p2_hat) / n2)
-
-
-def pooled_p(x1: int, n1: int, x2: int, n2: int) -> float:
-    """Pooled estimator \u0302p under H0 : p1 = p2 (Lecture 9, slide 25)."""
-    return (x1 + x2) / (n1 + n2)
-
-
-def se_xbar_diff(s1: float, n1: int, s2: float, n2: int) -> float:
-    """Standard error of \bar X₁ − \bar X₂ (Lecture 10, slide 11)."""
-    return math.sqrt(s1 ** 2 / n1 + s2 ** 2 / n2)
-
-
-def margin_of_error_z(s: float, n: int, z: float = 1.96) -> float:
-    """Margin of error for a large‑sample CI for a mean (Lecture 11, slide 6).
-
-    ME = z*·s/√n
-    """
-    return z * s / math.sqrt(n)
-
-
-def ci_mu1_minus_mu2(
-    mean1: float,
-    mean2: float,
-    s1: float,
-    n1: int,
-    s2: float,
-    n2: int,
-    z: float = 1.96,
-) -> Tuple[float, float]:
-    r"""Large‑sample CI for \mu_1 - \mu_2 (Lecture 11, slide 12)."""
-    diff = mean1 - mean2
-    se = se_xbar_diff(s1, n1, s2, n2)
-    me = z * se
-    return diff - me, diff + me
-
-
-def t_stat_one_mean(xbar: float, mu0: float, s: float, n: int) -> float:
-    r"""Student-t statistic for H0 : \mu = \mu_0 (Lecture 12, slide 7)."""
-    return (xbar - mu0) / (s / math.sqrt(n))
-
-
-def df_paired(n: int) -> int:
-    """Degrees of freedom for paired‑sample t procedures (Lecture 12, slide 17)."""
-    return n - 1
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Quick‑and‑dirty unit tests against the published answer key
@@ -82,11 +49,6 @@ def df_paired(n: int) -> int:
 Answer = Union[float, Tuple[float, float]]
 
 
-def approx(a: Answer, b: Answer, tol: float = 5e-3) -> bool:  # noqa: W605
-    """Flexible tolerance‑based comparison (scalar or 2‑tuple)."""
-    if isinstance(a, tuple):
-        return all(abs(x - y) <= tol for x, y in zip(a, b))
-    return abs(a - b) <= tol
 
 
 def run_self_checks() -> None:

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Helper utilities for PS-generator tools."""

--- a/tools/validation_utils.py
+++ b/tools/validation_utils.py
@@ -1,0 +1,127 @@
+"""Common statistical helpers for validation pipelines.
+
+Functions mirror the notation used in the lecture slides so validation code
+matches the formulas presented in class.
+"""
+
+from __future__ import annotations
+
+import math
+from statistics import NormalDist
+from typing import Tuple
+
+from scipy.stats import t as t_dist
+
+# ---------------------------------------------------------------------------
+# Generic helpers
+# ---------------------------------------------------------------------------
+
+def margin_of_error(se: float, crit: float) -> float:
+    """Return ``crit`` × ``se`` (Lecture 11, slide 6)."""
+    return crit * se
+
+
+def margin_of_error_z(s: float, n: int, z: float = 1.96) -> float:
+    """Margin of error for a mean using z procedures."""
+    return margin_of_error(s / math.sqrt(n), z)
+
+
+def p_value(stat: float, two_sided: bool = True, distribution: str = "z", df: int | None = None) -> float:
+    """P-value for a z or t statistic."""
+    abs_stat = abs(stat)
+    if distribution == "z":
+        tail = 1 - NormalDist().cdf(abs_stat)
+    elif distribution == "t":
+        if df is None:
+            raise ValueError("df required for t distribution")
+        tail = 1 - t_dist.cdf(abs_stat, df)
+    else:
+        raise ValueError("distribution must be 'z' or 't'")
+    return 2 * tail if two_sided else (tail if stat > 0 else 1 - tail)
+
+# ---------------------------------------------------------------------------
+# Proportion inference
+# ---------------------------------------------------------------------------
+
+def se_hat_p_diff(p1_hat: float, n1: int, p2_hat: float, n2: int) -> float:
+    """SE of ``hat p1 - hat p2`` (Lecture 9, slide 12)."""
+    return math.sqrt(p1_hat * (1 - p1_hat) / n1 + p2_hat * (1 - p2_hat) / n2)
+
+
+def pooled_p(x1: int, n1: int, x2: int, n2: int) -> float:
+    """Pooled estimator for H0: p1 = p2 (Lecture 9, slide 25)."""
+    return (x1 + x2) / (n1 + n2)
+
+
+def se_pooled_p_diff(x1: int, n1: int, x2: int, n2: int) -> float:
+    """SE of ``hat p1 - hat p2`` under H0 (Lecture 9, slide 25)."""
+    p_hat = pooled_p(x1, n1, x2, n2)
+    return math.sqrt(p_hat * (1 - p_hat) * (1 / n1 + 1 / n2))
+
+
+def z_stat_two_props(x1: int, n1: int, x2: int, n2: int) -> float:
+    """Z statistic for testing ``p1 = p2`` (Lecture 9, slide 24)."""
+    p1_hat = x1 / n1
+    p2_hat = x2 / n2
+    se0 = se_pooled_p_diff(x1, n1, x2, n2)
+    return (p1_hat - p2_hat) / se0
+
+
+def ci_p1_minus_p2(p1_hat: float, n1: int, p2_hat: float, n2: int, z: float = 1.96) -> Tuple[float, float]:
+    """Large-sample CI for ``p1 - p2`` (Lecture 9, slide 15)."""
+    diff = p1_hat - p2_hat
+    se = se_hat_p_diff(p1_hat, n1, p2_hat, n2)
+    me = margin_of_error(se, z)
+    return diff - me, diff + me
+
+# ---------------------------------------------------------------------------
+# Mean inference
+# ---------------------------------------------------------------------------
+
+def se_xbar_diff(s1: float, n1: int, s2: float, n2: int) -> float:
+    """SE of ``Xbar1 - Xbar2`` (Lecture 10, slide 11)."""
+    return math.sqrt(s1 ** 2 / n1 + s2 ** 2 / n2)
+
+
+def ci_mu1_minus_mu2(mean1: float, mean2: float, s1: float, n1: int, s2: float, n2: int, z: float = 1.96) -> Tuple[float, float]:
+    """Large-sample CI for ``mu1 - mu2`` (Lecture 11, slide 12)."""
+    diff = mean1 - mean2
+    se = se_xbar_diff(s1, n1, s2, n2)
+    me = margin_of_error(se, z)
+    return diff - me, diff + me
+
+
+def t_stat_one_mean(xbar: float, mu0: float, s: float, n: int) -> float:
+    """Student-t statistic for ``mu = mu0`` (Lecture 12, slide 7)."""
+    return (xbar - mu0) / (s / math.sqrt(n))
+
+
+def t_stat_two_means(mean1: float, mean2: float, s1: float, n1: int, s2: float, n2: int, delta0: float = 0.0) -> float:
+    """Welch t statistic for ``mu1 - mu2`` (Lecture 12, slide 27)."""
+    se = se_xbar_diff(s1, n1, s2, n2)
+    return ((mean1 - mean2) - delta0) / se
+
+
+def df_paired(n: int) -> int:
+    """Degrees of freedom for paired-sample t (Lecture 12, slide 17)."""
+    return n - 1
+
+
+def df_welch(s1: float, n1: int, s2: float, n2: int) -> float:
+    """Welch–Satterthwaite df approximation."""
+    num = (s1 ** 2 / n1 + s2 ** 2 / n2) ** 2
+    den = (s1 ** 4) / (n1 ** 2 * (n1 - 1)) + (s2 ** 4) / (n2 ** 2 * (n2 - 1))
+    return num / den
+
+
+def t_stat_paired(d_bar: float, mu_d0: float, s_d: float, n: int) -> float:
+    """t statistic for paired differences."""
+    return (d_bar - mu_d0) / (s_d / math.sqrt(n))
+
+# Convenience for self-tests ------------------------------------------------
+
+def approx(a, b, tol: float = 5e-3) -> bool:
+    """Return True if ``a`` ≈ ``b`` within ``tol``."""
+    if isinstance(a, tuple):
+        return all(abs(x - y) <= tol for x, y in zip(a, b))
+    return abs(a - b) <= tol


### PR DESCRIPTION
## Summary
- implement general margin of error
- add z-based CI and statistic for two proportions
- add Welch t helpers and paired tests
- provide generic p-value function
- consolidate helpers in `tools.validation_utils`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867aef2af54833281d4820855b3f86d