### PR TITLE
Add PDF build dependencies

### DIFF
--- a/generator/requirements.txt
+++ b/generator/requirements.txt
@@ -1,0 +1,4 @@
+# Python packages required for PDF build pipeline
+jinja2>=3.1
+
+# System requirement: a LaTeX distribution providing `pdflatex`


### PR DESCRIPTION
## Summary
- add generator/requirements.txt with Jinja dependency and note about pdflatex

## Testing
- `pip install -r generator/requirements.txt`
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c011fcc883329d76443793ea076b