### PR TITLE
Add Problem Set 3 web app and blueprint parser

### DIFF
--- a/docs/web_app_protocol.md
+++ b/docs/web_app_protocol.md
@@ -48,4 +48,19 @@ Because all data comes from `question_bank.json`, the same `script.js` works acr
 5. Place any lecture PDFs in `lecture-slides/` for reference.
 6. Commit the new directory. The app will run entirely from these files—no external dependencies beyond MathJax and Tailwind CDN links in `index.html`.
 
+## Converting Blueprint Markdown
+
+When instructors provide a Markdown blueprint containing JSON question objects (as in `problem-set-3/problem_set_blueprint.md`), run a small parser to transform the blocks into `question_bank.json`.
+
+1. Extract each fenced `jsonc` code block.
+2. Convert the blueprint keys to the minimal bank schema:
+   - `stem` → `text`
+   - first tag from `tags` → `topic_short`
+   - `choices` → array of `{text, value}` with values `a`–`d`
+   - `answer` → `correctAnswer` (lower‑cased)
+   - `rationale` → `explanation`
+3. Number the items sequentially as the `id` field.
+
+The helper script `problem-set-3/parse_blueprint.py` demonstrates this process for Week 5 and writes `question_bank.json` in the same folder.
+
 Following this protocol ensures each problem set is independent and can be zipped or hosted individually. Future enhancements, such as additional metadata fields or styling changes, can be incorporated without breaking existing sets as long as the core JSON structure remains an array of question objects with the fields listed above.

--- a/problem-set-3/parse_blueprint.py
+++ b/problem-set-3/parse_blueprint.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import List, Dict
+
+
+def extract_question_blocks(md_text: str) -> List[Dict]:
+    pattern = re.compile(r"```jsonc\n(.*?)```", re.DOTALL)
+    blocks = pattern.findall(md_text)
+    questions = []
+    for block in blocks:
+        obj = json.loads(block)
+        questions.append(obj)
+    return questions
+
+
+def convert_to_bank(objs: List[Dict]) -> List[Dict]:
+    bank = []
+    for idx, obj in enumerate(objs, start=1):
+        options = []
+        for key, val in obj["choices"].items():
+            options.append({"text": val, "value": key.lower()})
+        bank.append(
+            {
+                "id": idx,
+                "text": obj["stem"],
+                "topic_short": obj["tags"][0] if obj.get("tags") else obj.get("category", ""),
+                "options": options,
+                "correctAnswer": obj["answer"].lower(),
+                "explanation": obj["rationale"],
+            }
+        )
+    return bank
+
+
+def main() -> None:
+    md_path = Path("problem_set_blueprint.md")
+    out_path = Path("question_bank.json")
+    md_text = md_path.read_text(encoding="utf-8")
+    objs = extract_question_blocks(md_text)
+    bank = convert_to_bank(objs)
+    out_path.write_text(json.dumps(bank, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/problem-set-3/question_bank.json
+++ b/problem-set-3/question_bank.json
@@ -1,0 +1,502 @@
+[
+  {
+    "id": 1,
+    "text": "In the notation of Lecture\u00a09, what symbol represents the *population* proportion for group\u00a01?",
+    "topic_short": "two-proportions",
+    "options": [
+      {
+        "text": "\u0302p_1 (p-hat-one)",
+        "value": "a"
+      },
+      {
+        "text": "p_1",
+        "value": "b"
+      },
+      {
+        "text": "n_1",
+        "value": "c"
+      },
+      {
+        "text": "\u0394 (Delta)",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "Hats denote sample statistics; plain *p* denotes the true population parameter."
+  },
+  {
+    "id": 2,
+    "text": "Why does the difference of two sample proportions \u0302p_1-\u0302p_2 become approximately Normal as both sample sizes grow large?",
+    "topic_short": "CLT",
+    "options": [
+      {
+        "text": "Because each proportion is bounded between 0 and\u00a01.",
+        "value": "a"
+      },
+      {
+        "text": "Because the Central Limit Theorem applies independently to each \u0302p_i, and the sum/difference of Normals is Normal.",
+        "value": "b"
+      },
+      {
+        "text": "Because proportions follow a Student-t distribution for large n.",
+        "value": "c"
+      },
+      {
+        "text": "Because the Law of Large Numbers guarantees exact Normality.",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "CLT \u2192 each \u0302p_i ~ Normal; linear combinations of independent Normals remain Normal."
+  },
+  {
+    "id": 3,
+    "text": "Which distribution should you use for inference about a single mean when the sample size is 15 and the population standard deviation is unknown?",
+    "topic_short": "student-t",
+    "options": [
+      {
+        "text": "Standard Normal (Z)",
+        "value": "a"
+      },
+      {
+        "text": "Chi-square",
+        "value": "b"
+      },
+      {
+        "text": "Student-t with 14\u00a0df",
+        "value": "c"
+      },
+      {
+        "text": "F\u2011distribution",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "c",
+    "explanation": "Small n, unknown \u03c3 \u21d2 t_{n\u20111}."
+  },
+  {
+    "id": 4,
+    "text": "In large\u2011sample tests for two means, what role does the quantity \u0394_0 (Delta\u2011zero) play?",
+    "topic_short": "hypothesis-test",
+    "options": [
+      {
+        "text": "It is the pooled standard deviation.",
+        "value": "a"
+      },
+      {
+        "text": "It is the hypothesised difference between population means under H0.",
+        "value": "b"
+      },
+      {
+        "text": "It is the observed difference between sample means.",
+        "value": "c"
+      },
+      {
+        "text": "It is the margin of error.",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "Delta\u2011zero encodes the null\u2011hypothesised gap (often 0 but not always)."
+  },
+  {
+    "id": 5,
+    "text": "Which of the following scenarios *best* justifies a paired\u2011sample design rather than two independent samples?",
+    "topic_short": "paired",
+    "options": [
+      {
+        "text": "Comparing voter turnout rates between two different states in the same election year.",
+        "value": "a"
+      },
+      {
+        "text": "Comparing blood pressure of patients before and after taking a new medication.",
+        "value": "b"
+      },
+      {
+        "text": "Comparing average incomes of two unrelated demographic groups.",
+        "value": "c"
+      },
+      {
+        "text": "Comparing graduation rates of two schools in different cities.",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "Pre/post on same individuals = natural pairing."
+  },
+  {
+    "id": 6,
+    "text": "According to the decision tree on slide\u00a026, pooling variances in a two\u2011sample t\u00a0test is *most* reasonable when:",
+    "topic_short": "variance",
+    "options": [
+      {
+        "text": "Sample sizes are equal and population variances are plausibly equal.",
+        "value": "a"
+      },
+      {
+        "text": "One sample is twice the size of the other but sample SDs match exactly.",
+        "value": "b"
+      },
+      {
+        "text": "Sample variances differ by a factor of\u00a04 but sample sizes are large.",
+        "value": "c"
+      },
+      {
+        "text": "There is any evidence of unequal variances regardless of sample size.",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "Equal n + equal variance assumption allows pooled\u2011SD estimate."
+  },
+  {
+    "id": 7,
+    "text": "If a 95\u202f% confidence interval for \u03bc_1-\u03bc_2 does *not* contain\u00a00, what does this suggest at the 5\u202f% significance level?",
+    "topic_short": "confidence-interval",
+    "options": [
+      {
+        "text": "Fail to reject the null hypothesis of no difference.",
+        "value": "a"
+      },
+      {
+        "text": "Reject the null hypothesis of no difference.",
+        "value": "b"
+      },
+      {
+        "text": "The sample means are equal.",
+        "value": "c"
+      },
+      {
+        "text": "We need a larger sample to decide.",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "CI excluding 0 corresponds to significant result at matching \u03b1."
+  },
+  {
+    "id": 8,
+    "text": "A 95\u202f% CI for the vaccination rate difference was [\u22120.013,\u00a00.113]. Which statement best describes the implication for policymakers?",
+    "topic_short": "CI",
+    "options": [
+      {
+        "text": "There is evidence the vaccination rate is higher in group\u00a01 than group\u00a02.",
+        "value": "a"
+      },
+      {
+        "text": "There is no statistically significant difference at the 5\u202f% level.",
+        "value": "b"
+      },
+      {
+        "text": "Group\u00a02 definitely has a higher vaccination rate.",
+        "value": "c"
+      },
+      {
+        "text": "The true difference is exactly \u22120.013 or 0.113.",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "Interval crosses 0; difference not significant."
+  },
+  {
+    "id": 9,
+    "text": "A hypothesis test on average sleep hours produced Z\u00a0=\u00a0\u22122.67. Which p\u2011value range is correct for a two\u2011tailed test?",
+    "topic_short": "p-value",
+    "options": [
+      {
+        "text": "p\u00a0>\u00a00.10",
+        "value": "a"
+      },
+      {
+        "text": "0.05\u00a0<\u00a0p\u00a0\u2264\u00a00.10",
+        "value": "b"
+      },
+      {
+        "text": "0.01\u00a0<\u00a0p\u00a0\u2264\u00a00.05",
+        "value": "c"
+      },
+      {
+        "text": "p\u00a0\u2264\u00a00.01",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "c",
+    "explanation": "|Z|\u22482.67 \u21d2 p \u2248 0.0076 one\u2011tailed, 0.015 two\u2011tailed; falls between 1\u202f% and\u00a05\u202f%."
+  },
+  {
+    "id": 10,
+    "text": "A paired\u2011sample 95\u202f% CI for turnout change after an ID law is [\u22123.7\u00a0pp,\u00a00.1\u00a0pp]. Which is the *best* conclusion?",
+    "topic_short": "paired",
+    "options": [
+      {
+        "text": "Turnout definitely decreased by at least 3.7 percentage points.",
+        "value": "a"
+      },
+      {
+        "text": "Turnout definitely increased by up to 0.1\u00a0pp.",
+        "value": "b"
+      },
+      {
+        "text": "There is no strong evidence of a turnout change.",
+        "value": "c"
+      },
+      {
+        "text": "The law had a significant negative impact on turnout.",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "c",
+    "explanation": "Interval includes 0 \u21d2 cannot conclude change."
+  },
+  {
+    "id": 11,
+    "text": "For large independent samples, the statistic \u0305X_1-\u0305X_2 is approximately Normal. Which assumption is *not* required for this approximation?",
+    "topic_short": "sampling-distribution",
+    "options": [
+      {
+        "text": "Population variances are finite.",
+        "value": "a"
+      },
+      {
+        "text": "Samples are independent.",
+        "value": "b"
+      },
+      {
+        "text": "Population distributions are Normal.",
+        "value": "c"
+      },
+      {
+        "text": "Sample sizes are large.",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "c",
+    "explanation": "CLT removes shape requirement; only moments & large n matter."
+  },
+  {
+    "id": 12,
+    "text": "Increasing the confidence level from 90\u202f% to 99\u202f% while keeping n and s fixed will\u2026",
+    "topic_short": "margin-of-error",
+    "options": [
+      {
+        "text": "decrease the margin of error",
+        "value": "a"
+      },
+      {
+        "text": "increase the margin of error",
+        "value": "b"
+      },
+      {
+        "text": "leave the margin of error unchanged",
+        "value": "c"
+      },
+      {
+        "text": "make the CI narrower",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "Critical z* grows as confidence \u2191 \u21d2 wider interval."
+  },
+  {
+    "id": 13,
+    "text": "Slide\u00a031 warns about \u2018multiple testing\u2019. Which practice best mitigates inflated Type\u00a0I error in this context?",
+    "topic_short": "multiple-testing",
+    "options": [
+      {
+        "text": "Using two\u2011tailed tests instead of one\u2011tailed tests.",
+        "value": "a"
+      },
+      {
+        "text": "Applying a Bonferroni correction when several hypotheses are tested.",
+        "value": "b"
+      },
+      {
+        "text": "Reporting confidence intervals instead of p\u2011values.",
+        "value": "c"
+      },
+      {
+        "text": "Increasing sample size for each test.",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "Bonferroni or similar controls family\u2011wise error."
+  },
+  {
+    "id": 14,
+    "text": "Group\u00a01: n=200, \u0302p_1=0.40; Group\u00a02: n=250, \u0302p_2=0.32.  Compute the standard error of \u0302p_1-\u0302p_2 (rounded to 3\u00a0dp).",
+    "topic_short": "SE",
+    "options": [
+      {
+        "text": "0.043",
+        "value": "a"
+      },
+      {
+        "text": "0.046",
+        "value": "b"
+      },
+      {
+        "text": "0.061",
+        "value": "c"
+      },
+      {
+        "text": "0.073",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "SE = sqrt[p1(1-p1)/n1 + p2(1-p2)/n2] \u2248 0.0455 \u2192 0.046."
+  },
+  {
+    "id": 15,
+    "text": "Two samples yield x1=60 of 200, x2=55 of 180 successes.  Compute the pooled proportion \u0302p used in the z\u00a0test for H0: p1=p2.",
+    "topic_short": "pooled",
+    "options": [
+      {
+        "text": "0.303",
+        "value": "a"
+      },
+      {
+        "text": "0.315",
+        "value": "b"
+      },
+      {
+        "text": "0.333",
+        "value": "c"
+      },
+      {
+        "text": "0.645",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "\u0302p = (60 + 55) / (200 + 180) = 115 / 380 \u2248 0.303; choice A now reflects this rounded value."
+  },
+  {
+    "id": 16,
+    "text": "Sample1: n=120, \u0305x_1=52, s1=11; Sample2: n=110, \u0305x_2=48, s2=9.  Compute the 95\u202f% CI for \u03bc_1-\u03bc_2 (use z\u2011critical 1.96). Which interval is correct?",
+    "topic_short": "CI",
+    "options": [
+      {
+        "text": "[\u22121.6,\u00a09.6]",
+        "value": "a"
+      },
+      {
+        "text": "[\u22120.8,\u00a08.8]",
+        "value": "b"
+      },
+      {
+        "text": "[0.8,\u00a07.2]",
+        "value": "c"
+      },
+      {
+        "text": "[1.4,\u00a06.6]",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "d",
+    "explanation": "SE = \u221a(11^2/120 + 9^2/110) \u2248 1.32; ME = 1.96\u00d71.32 \u2248 2.59; diff = 4 \u00b1 2.59 \u2192 [1.41, 6.59] rounded to [1.4, 6.6]."
+  },
+  {
+    "id": 17,
+    "text": "Commute study: n=100, s=7\u202fmin, 95\u202f% CI.  Compute the margin of error (use z=1.96).",
+    "topic_short": "ME",
+    "options": [
+      {
+        "text": "0.69\u202fmin",
+        "value": "a"
+      },
+      {
+        "text": "1.37\u202fmin",
+        "value": "b"
+      },
+      {
+        "text": "2.45\u202fmin",
+        "value": "c"
+      },
+      {
+        "text": "13.72\u202fmin",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "ME = 1.96\u00b7(7/\u221a100)=1.372."
+  },
+  {
+    "id": 18,
+    "text": "Booth\u2011time data: n=12, \u0305x=7.8\u202fmin, \u03bc0=7\u202fmin, s=0.9\u202fmin.  Compute the t\u00a0statistic.",
+    "topic_short": "t-test",
+    "options": [
+      {
+        "text": "t=0.89",
+        "value": "a"
+      },
+      {
+        "text": "t=1.67",
+        "value": "b"
+      },
+      {
+        "text": "t=2.67",
+        "value": "c"
+      },
+      {
+        "text": "t=3.08",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "d",
+    "explanation": "t = (7.8 - 7) / (0.9 / \u221a12) \u2248 3.08."
+  },
+  {
+    "id": 19,
+    "text": "A paired study records n=18 differences.  What are the degrees of freedom for the associated t\u00a0test?",
+    "topic_short": "paired",
+    "options": [
+      {
+        "text": "17",
+        "value": "a"
+      },
+      {
+        "text": "18",
+        "value": "b"
+      },
+      {
+        "text": "34",
+        "value": "c"
+      },
+      {
+        "text": "36",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "a",
+    "explanation": "df = n\u20111 for paired mean differences."
+  },
+  {
+    "id": 20,
+    "text": "Compute the approximate SE of \u0305X_1-\u0305X_2 for small samples: n1=15, s1=4; n2=12, s2=5.",
+    "topic_short": "welch",
+    "options": [
+      {
+        "text": "1.44",
+        "value": "a"
+      },
+      {
+        "text": "1.77",
+        "value": "b"
+      },
+      {
+        "text": "2.12",
+        "value": "c"
+      },
+      {
+        "text": "2.56",
+        "value": "d"
+      }
+    ],
+    "correctAnswer": "b",
+    "explanation": "SE = \u221a(4^2/15 + 5^2/12) \u2248 1.77."
+  }
+]

--- a/problem-set-3/web_app/index.html
+++ b/problem-set-3/web_app/index.html
@@ -1,14 +1,124 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <title>Week 5 Quiz (Coming Soon)</title>
-  </head>
-  <body>
-    <!--
-      Quiz placeholder.
-      The final questions will be injected from question_bank.json
-      once problem_set_blueprint.md is converted.
-    -->
-  </body>
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Two-Sample Inference Problem Set</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+    <!-- MathJax Configuration -->
+    <script>
+        window.MathJax = {
+            tex: {
+                inlineMath: [['\\(', '\\)']], // Defines inline math delimiters
+                displayMath: [['\\[', '\\]']]  // Defines display math delimiters
+            },
+            chtml: {
+                linebreaks: {
+                    automatic: true, // Enable automatic line breaking
+                    inline: true    // Allow inline math to break
+                },
+                matchFontHeight: true,
+                scale: 1,
+            },
+            startup: {
+                ready: () => {
+                    MathJax.startup.defaultReady();
+                }
+            }
+        };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" async=""></script>
+
+    <style>
+        /* Custom styles for better mobile experience and aesthetics */
+        body {
+            font-family: 'Inter', sans-serif;
+        }
+
+        .question-option-label {
+            display: flex;
+            align-items: center;
+            padding: 0.75rem;
+            /* 12px */
+            border-width: 1px;
+            border-radius: 0.5rem;
+            /* 8px */
+            cursor: pointer;
+            transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;
+            border-color: #e5e7eb;
+            /* gray-200 */
+        }
+
+        .question-option-label:hover {
+            background-color: #f9fafb;
+            /* gray-50 */
+        }
+        
+        .feedback-correct {
+            border-left: 4px solid #10b981;
+            /* green-500 */
+            background-color: #f0fdf4;
+            /* green-50 */
+        }
+
+        .feedback-incorrect {
+            border-left: 4px solid #ef4444;
+            /* red-500 */
+            background-color: #fef2f2;
+            /* red-50 */
+        }
+
+        .feedback-explanation {
+            background-color: #f3f4f6;
+            /* gray-100 */
+            border: 1px solid #e5e7eb;
+            /* gray-200 */
+            border-radius: 0.375rem;
+            /* 6px */
+            padding: 0.75rem;
+            /* 12px */
+            margin-top: 0.75rem;
+            /* 12px */
+            font-size: 0.875rem;
+            /* 14px */
+            color: #4b5563;
+            /* gray-600 */
+        }
+        
+        /* Ensure MathJax content reflows properly */
+        mjx-container {
+            overflow-x: auto;
+            overflow-y: hidden;
+        }
+    </style>
+</head>
+
+<body class="bg-slate-100 min-h-screen p-4 sm:p-8">
+    <div class="max-w-3xl mx-auto bg-white p-6 sm:p-8 rounded-xl shadow-2xl">
+        <header class="mb-6 sm:mb-8 text-center">
+            <h1 class="text-3xl sm:text-4xl font-bold text-indigo-700">Two-Sample Inference Self-Assessment</h1>
+            <p class="text-gray-600 mt-2 text-sm sm:text-base">Test your understanding of inference for two proportions and two means under both large- and small-sample scenarios. Select an answer for each question and submit at the end for feedback.</p>
+        </header>
+
+        <div id="quiz-area">
+            <div id="question-container" class="mb-6">
+                <!-- Question will be loaded here -->
+            </div>
+            <div id="navigation-controls" class="flex justify-between items-center">
+                <!-- Navigation buttons will be here -->
+            </div>
+        </div>
+
+        <div id="results-container" class="hidden">
+            <!-- Results will be loaded here -->
+        </div>
+    </div>
+
+    <script src="script.js"></script>
+</body>
 </html>

--- a/problem-set-3/web_app/script.js
+++ b/problem-set-3/web_app/script.js
@@ -1,0 +1,186 @@
+"use strict";
+
+const CACHE_VERSION = "2024-05-01";
+let questions = [];
+let currentQuestionIndex = 0;
+const userAnswers = {};
+
+const quizArea = document.getElementById("quiz-area");
+const questionContainer = document.getElementById("question-container");
+const navigationControls = document.getElementById("navigation-controls");
+const resultsContainer = document.getElementById("results-container");
+resultsContainer.setAttribute("aria-live", "polite");
+
+async function loadQuestions() {
+  const res = await fetch(`question_bank.json?v=${CACHE_VERSION}`);
+  if (!res.ok) {
+    throw new Error("Failed to load question bank");
+  }
+  questions = await res.json();
+}
+
+function shuffleArray(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}
+
+function renderQuestion() {
+  const q = questions[currentQuestionIndex];
+  const opts = [...q.options];
+  shuffleArray(opts);
+  const optionsHTML = opts
+    .map(
+      (opt) => `
+      <label class="question-option-label group hover:bg-indigo-50 hover:border-indigo-300 ${
+        userAnswers[q.id] === opt.value
+          ? "bg-indigo-100 border-indigo-400 ring-2 ring-indigo-300"
+          : "border-gray-300"
+      }">
+        <input type="radio" name="q${q.id}" value="${opt.value}"
+          class="form-radio h-5 w-5 text-indigo-600 focus:ring-indigo-500 mr-3 shrink-0"
+          ${userAnswers[q.id] === opt.value ? "checked" : ""}
+          onchange="handleOptionChange(${q.id}, '${opt.value}')">
+        <span class="text-gray-700 group-hover:text-indigo-700">${opt.text}</span>
+      </label>`
+    )
+    .join("");
+  questionContainer.innerHTML = `
+    <fieldset class="p-3 sm:p-5 border border-gray-200 rounded-lg shadow-sm bg-white">
+      <legend class="text-base sm:text-lg text-gray-800 mb-4 leading-relaxed">
+        Question ${currentQuestionIndex + 1} of ${questions.length}: ${q.text}
+      </legend>
+      <div class="space-y-3 options-group">${optionsHTML}</div>
+    </fieldset>`;
+
+  renderNavigation();
+
+  if (window.MathJax && window.MathJax.typesetPromise) {
+    window.MathJax.typesetPromise([questionContainer]);
+  }
+}
+
+function renderNavigation() {
+  navigationControls.innerHTML = "";
+  if (currentQuestionIndex > 0) {
+    const prevBtn = document.createElement("button");
+    prevBtn.textContent = "Previous";
+    prevBtn.className =
+      "bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-2 px-4 rounded-lg shadow-md transition-colors duration-150 ease-in-out";
+    prevBtn.onclick = prevQuestion;
+    navigationControls.appendChild(prevBtn);
+  }
+
+  const spacer = document.createElement("div");
+  spacer.className = "flex-grow";
+  navigationControls.appendChild(spacer);
+
+  if (currentQuestionIndex < questions.length - 1) {
+    const nextBtn = document.createElement("button");
+    nextBtn.textContent = "Next Question";
+    nextBtn.className =
+      "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition-colors duration-150 ease-in-out";
+    nextBtn.onclick = nextQuestion;
+    navigationControls.appendChild(nextBtn);
+  } else {
+    const submitBtn = document.createElement("button");
+    submitBtn.textContent = "Submit Answers";
+    submitBtn.className =
+      "bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-6 rounded-lg shadow-md transition-colors duration-150 ease-in-out";
+    submitBtn.onclick = submitQuiz;
+    navigationControls.appendChild(submitBtn);
+  }
+}
+
+function handleOptionChange(id, value) {
+  userAnswers[id] = value;
+  const radios = document.getElementsByName(`q${id}`);
+  radios.forEach((radio) => {
+    const label = radio.closest("label");
+    if (radio.value === value) {
+      label.classList.add("bg-indigo-100", "border-indigo-400", "ring-2", "ring-indigo-300");
+      label.classList.remove("border-gray-300");
+    } else {
+      label.classList.remove("bg-indigo-100", "border-indigo-400", "ring-2", "ring-indigo-300");
+      label.classList.add("border-gray-300");
+    }
+  });
+}
+
+function prevQuestion() {
+  if (currentQuestionIndex > 0) {
+    currentQuestionIndex--;
+    renderQuestion();
+  }
+}
+
+function nextQuestion() {
+  if (currentQuestionIndex < questions.length - 1) {
+    currentQuestionIndex++;
+    renderQuestion();
+  }
+}
+
+function submitQuiz() {
+  quizArea.classList.add("hidden");
+  resultsContainer.classList.remove("hidden");
+  let correct = 0;
+  let resultsHTML = `<h2 class="text-2xl sm:text-3xl font-bold text-gray-800 mb-6 text-center">Your Results</h2>`;
+  questions.forEach((q, index) => {
+    const userAns = userAnswers[q.id];
+    const isCorrect = userAns === q.correctAnswer;
+    if (isCorrect) correct++;
+    const optionsFeedbackHTML = q.options
+      .map((opt) => {
+        let classes = "p-2 rounded-md text-sm sm:text-base ";
+        let indicator = "";
+        if (opt.value === q.correctAnswer) {
+          classes += "bg-green-100 border border-green-300 text-green-800 font-semibold";
+          indicator = userAns === opt.value ? " (Your Answer - Correct)" : " (Correct Answer)";
+        } else if (userAns === opt.value) {
+          classes += "bg-red-100 border border-red-300 text-red-800 font-semibold";
+          indicator = " (Your Answer - Incorrect)";
+        } else {
+          classes += "bg-gray-50 border border-gray-200 text-gray-700";
+        }
+        return `<div class="${classes}">${opt.text}${indicator}</div>`;
+      })
+      .join("");
+
+    resultsHTML += `
+      <div class="p-4 sm:p-5 rounded-lg shadow-md mb-6 ${isCorrect ? "feedback-correct" : "feedback-incorrect"}">
+        <p class="text-sm font-medium text-gray-700 mb-1">Question ${index + 1}: ${q.topic_short}</p>
+        <p class="text-base sm:text-lg text-gray-900 mb-3">${q.text}</p>
+        <div class="space-y-2 mb-3">${optionsFeedbackHTML}</div>
+        <div class="feedback-explanation">${q.explanation}</div>
+      </div>`;
+  });
+
+  resultsHTML = `
+    <div class="text-center mb-8">
+      <p class="text-xl sm:text-2xl font-semibold text-gray-800">You answered ${correct} out of ${questions.length} questions correctly.</p>
+      <p class="text-lg text-indigo-600">${((correct / questions.length) * 100).toFixed(1)}%</p>
+    </div>` + resultsHTML;
+
+  resultsContainer.innerHTML = resultsHTML;
+  if (window.MathJax && window.MathJax.typesetPromise) {
+    window.MathJax.typesetPromise([resultsContainer]);
+  }
+}
+
+async function startQuiz() {
+  try {
+    await loadQuestions();
+    renderQuestion();
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "ArrowRight") nextQuestion();
+      else if (e.key === "ArrowLeft") prevQuestion();
+    });
+  } catch (err) {
+    quizArea.innerHTML = '<p class="text-red-600">Unable to load questions.</p>';
+    console.error(err);
+  }
+}
+
+document.addEventListener("DOMContentLoaded", startQuiz);

--- a/problem-set-3/web_app/styles.css
+++ b/problem-set-3/web_app/styles.css
@@ -1,4 +1,28 @@
-/*
-  Stylesheet placeholder. Detailed styles will be added when the
-  Week 5 quiz content is finalised and question_bank.json is available.
-*/
+body {
+	padding: 2rem;
+	font-family: -apple-system, BlinkMacSystemFont, "Arial", sans-serif;
+}
+
+h1 {
+	font-size: 16px;
+	margin-top: 0;
+}
+
+p {
+	color: rgb(107, 114, 128);
+	font-size: 15px;
+	margin-bottom: 10px;
+	margin-top: 5px;
+}
+
+.card {
+	max-width: 620px;
+	margin: 0 auto;
+	padding: 16px;
+	border: 1px solid lightgray;
+	border-radius: 16px;
+}
+
+.card p:last-child {
+	margin-bottom: 0;
+}


### PR DESCRIPTION
## Summary
- add parser for blueprint JSON blocks
- generate `question_bank.json` for problem set 3
- copy web app assets from problem set 2 and update the landing page
- document how to convert a blueprint into a question bank

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867c2babda88332aec07b2d4a344d05